### PR TITLE
Added support for non string filtering as well as for non string nullable filtering

### DIFF
--- a/PrimeNG.TableFilter.Test/PrimeNGTableFilterIEnumerableTest.cs
+++ b/PrimeNG.TableFilter.Test/PrimeNGTableFilterIEnumerableTest.cs
@@ -13,26 +13,29 @@ namespace PrimeNG.TableFilter.Test
         {
             return new List<TestData>
             {
-                new TestData
-                {
-                    DateTime1 = new DateTime(2019, 1, 10), Num1 = 1, String1 = "Test1",
-                    DateTime2 = new DateTime(2019, 2, 10), Num2 = 1
-                },
-                new TestData { DateTime1 = new DateTime(2019, 1, 11), Num1 = 2, String1 = "Test2", Num2 = 2 },
-                new TestData { DateTime1 = new DateTime(2019, 1, 12), Num1 = 3, String1 = "Test3", Num2 = 1 },
-                new TestData { DateTime1 = new DateTime(2019, 1, 13), Num1 = 4, String1 = "Test4", Num2 = 6 },
+                new TestData { DateTime1  = new DateTime(2019, 1, 10), Num1 = 1, String1 = "Test1", DateTime2 = new DateTime(2019, 2, 10) },
+                new TestData { DateTime1 = new DateTime(2019, 1, 11), Num1 = 2, String1 = "Test2" },
+                new TestData { DateTime1 = new DateTime(2019, 1, 12), Num1 = 3, String1 = "Test3" },
+                new TestData { DateTime1 = new DateTime(2019, 1, 13), Num1 = 4, String1 = "Test4" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 14), Num1 = 5, String1 = "Test5" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 15), Num1 = 6, String1 = "Test5" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 16), Num1 = 7, String1 = "Test6" },
-                new TestData
-                {
-                    DateTime1 = new DateTime(2019, 1, 17), Num1 = 8, String1 = "Test7",
-                    DateTime2 = new DateTime(2019, 2, 17)
-                },
+                new TestData { DateTime1 = new DateTime(2019, 1, 17), Num1 = 8, String1 = "Test7", DateTime2 = new DateTime(2019, 2, 17) },
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Test7" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best1" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best2" },
-                new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best3", Num2 = 5 },
+                new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best3" },
+                // nullable TestData
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=false },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=true },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=true },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableShort=5},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableInt=12},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", NullableLong=55 },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B3", NullableFloat=(float?)5.1},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T7", NullableDouble=10.2},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableDecimal = (decimal?)22.5 },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", DateTime2 = new DateTime(2021,11,5) },
             };
         }
 
@@ -44,9 +47,10 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {} , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"num1\",sortOrder: 1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
@@ -54,9 +58,10 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {} , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
@@ -65,7 +70,7 @@ namespace PrimeNG.TableFilter.Test
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test\", matchMode: \"contains\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData().Where(o => o.Num1 == 1);
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(1, dataSet.Count());
+            Assert.Single(dataSet);
             Assert.Equal(1, totalRecord);
         }
 
@@ -102,7 +107,7 @@ namespace PrimeNG.TableFilter.Test
         [Fact]
         public void Order_Table_Field_DateTime1_Where_2019_1_16_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { dateTime1: { value: \"2019-01-16T00:00:00.000Z\", matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime1: { value: \"2019-01-16T00:00:00.000Z\", matchMode: \"dateIs\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal("Test6", dataSet.FirstOrDefault()?.String1);
@@ -115,7 +120,7 @@ namespace PrimeNG.TableFilter.Test
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test7\", matchMode: \"contains\" }, num1: { value: \"9\", matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(1, dataSet.Count());
+            Assert.Single(dataSet);
             Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(1, totalRecord);
         }
@@ -125,11 +130,12 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {} , first: 3, globalFilter: null, multiSortMeta: undefined, rows: 5, sortField: \"\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(5, dataSet.Count());
             Assert.Equal(4, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(8, dataSet.LastOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
@@ -147,9 +153,10 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: 1 }, { field: \"string1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
         }
@@ -158,20 +165,22 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: -1 }, { field: \"string1\", order: -1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(3, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal(counted, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
         }
         [Fact]
         public void List_Multiple_Sorting_Mix_Asc_Desc_Test()
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: 1 }, { field: \"string1\", order: -1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
             Assert.Equal("Test1", dataSet.FirstOrDefault()?.String1);
@@ -183,13 +192,14 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: -1 }, { field: \"string1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(3, dataSet.LastOrDefault()?.Num1);
-            Assert.Equal("Best1", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal("Test3", dataSet.LastOrDefault()?.String1);
+            Assert.Equal(counted, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal("B1", dataSet.FirstOrDefault()?.String1);
+            Assert.Equal("T7", dataSet.LastOrDefault()?.String1);
         }
         
         [Fact]
@@ -197,20 +207,21 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"string1\", order: -1 }, { field: \"num1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(8, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
             Assert.Equal("Test7", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal("Best3", dataSet.LastOrDefault()?.String1);
+            Assert.Equal("T7", dataSet.LastOrDefault()?.String1);
         }
 
 
         [Fact]
         public void List_Field_DateTime2_Where_2019_2_17_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2019-02-17T00:00:00.000Z\", matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2019-02-17T00:00:00.000Z\", matchMode: \"dateIs\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal("Test7", dataSet.FirstOrDefault()?.String1);
@@ -222,9 +233,10 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{}");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(0, dataSet.Count());
+            Assert.Equal(counted, totalRecord);
+            Assert.Empty(dataSet);
         }
         
         [Fact]
@@ -232,8 +244,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: null, matchMode: \"startsWith\" }, num1: { value: null, matchMode: \"startsWith\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact] 
@@ -241,8 +254,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string2: { value: \"Test\", matchMode: \"equals\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact] 
@@ -250,8 +264,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test5\", matchMode: \"notContains\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x=>!x.String1.Contains("Test5"));
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(10, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact] 
@@ -259,8 +274,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test1\", matchMode: \"notEquals\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => !x.String1.Contains("Test1"));
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(11, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact]
@@ -280,15 +296,29 @@ namespace PrimeNG.TableFilter.Test
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(1, totalRecord);
         }
-        
         [Fact]
-        public void Order_Table_Field_Num2_Where_5_Test()
+        public void NullableBoolFilterShouldReturnSingleElement()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { num2: { value: 5, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: false, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal("Best3", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal(1, totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        public void NullableBoolFilterShouldReturnTwoElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: true, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(2,totalRecord);
+        }
+        [Fact]
+        public void NullablShortFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
         }
     }
 }

--- a/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
+++ b/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
@@ -13,10 +13,10 @@ namespace PrimeNG.TableFilter.Test
         {
             return new List<TestData>
             {
-                new TestData { DateTime1  = new DateTime(2019, 1, 10), Num1 = 1, String1 = "Test1", DateTime2 = new DateTime(2019, 2, 10), Num2 = 1 },
-                new TestData { DateTime1 = new DateTime(2019, 1, 11), Num1 = 2, String1 = "Test2", Num2 = 2 },
-                new TestData { DateTime1 = new DateTime(2019, 1, 12), Num1 = 3, String1 = "Test3", Num2 = 1 },
-                new TestData { DateTime1 = new DateTime(2019, 1, 13), Num1 = 4, String1 = "Test4", Num2 = 6 },
+                new TestData { DateTime1  = new DateTime(2019, 1, 10), Num1 = 1, String1 = "Test1", DateTime2 = new DateTime(2019, 2, 10) },
+                new TestData { DateTime1 = new DateTime(2019, 1, 11), Num1 = 2, String1 = "Test2" },
+                new TestData { DateTime1 = new DateTime(2019, 1, 12), Num1 = 3, String1 = "Test3" },
+                new TestData { DateTime1 = new DateTime(2019, 1, 13), Num1 = 4, String1 = "Test4" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 14), Num1 = 5, String1 = "Test5" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 15), Num1 = 6, String1 = "Test5" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 16), Num1 = 7, String1 = "Test6" },
@@ -24,7 +24,25 @@ namespace PrimeNG.TableFilter.Test
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Test7" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best1" },
                 new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best2" },
-                new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best3", Num2 = 5 },
+                new TestData { DateTime1 = new DateTime(2019, 1, 18), Num1 = 9, String1 = "Best3" },
+                // nullable TestData
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=false },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=true },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T1", NullableBool=true },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableShort=5},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableShort=6},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableInt=12},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableInt=13},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", NullableLong=55},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableLong=56},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B3", NullableFloat=(float?)5.1},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B3", NullableFloat=(float?)5.2},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T7", NullableDouble=10.2},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "T7", NullableDouble=10.3},
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableDecimal = (decimal?)22.5 },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableDecimal = (decimal?)22.6 },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", DateTime2 = new DateTime(2021,11,5) },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", DateTime2 = new DateTime(2021,11,8) },
             }.AsQueryable();
         }
 
@@ -36,19 +54,21 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {} , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"num1\",sortOrder: 1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
         public void Order_Table_Field_Num1_By_Desc_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: {} , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: {} , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"num1\",sortOrder: -1 }"); 
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
@@ -94,7 +114,7 @@ namespace PrimeNG.TableFilter.Test
         [Fact]
         public void Order_Table_Field_DateTime1_Where_2019_1_16_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { dateTime1: { value: \"2019-01-16T00:00:00.000Z\", matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime1: { value: \"2019-01-16T00:00:00.000Z\", matchMode: \"dateIs\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal("Test6", dataSet.FirstOrDefault()?.String1);
@@ -117,11 +137,12 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {} , first: 3, globalFilter: null, multiSortMeta: undefined, rows: 5, sortField: \"\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(5, dataSet.Count());
             Assert.Equal(4, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(8, dataSet.LastOrDefault()?.Num1);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact]
@@ -139,10 +160,11 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: 1 }, { field: \"string1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(counted, totalRecord);
+            Assert.Equal(dataSet.First().Num1, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
         }
         [Fact]
@@ -150,20 +172,22 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: -1 }, { field: \"string1\", order: -1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(3, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal(counted, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
         }
         [Fact]
         public void List_Multiple_Sorting_Mix_Asc_Desc_Test()
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: 1 }, { field: \"string1\", order: -1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(1, dataSet.FirstOrDefault()?.Num1);
             Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
             Assert.Equal("Test1", dataSet.FirstOrDefault()?.String1);
@@ -175,38 +199,43 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"num1\", order: -1 }, { field: \"string1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
-            Assert.Equal(9, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(3, dataSet.LastOrDefault()?.Num1);
-            Assert.Equal("Best1", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal("Test3", dataSet.LastOrDefault()?.String1);
+            Assert.Equal(counted, totalRecord);
+            Assert.Equal(90, dataSet.FirstOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal("B1", dataSet.FirstOrDefault()?.String1);
+            Assert.Equal("B2", dataSet.LastOrDefault()?.String1);
         }
         
         [Fact]
         public void List_Multiple_Sorting_Mix_Desc_Asc_Duplicate_First_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: 10, sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"string1\", order: -1 }, { field: \"num1\", order: 1 }] }");
+            int rows = 10;
+            var filter = GenerateFilterTableFromJson("{ filters: {}, first: 0, globalFilter: null, rows: "+rows+", sortField: \"\",sortOrder: -1, multiSortMeta: [{ field: \"string1\", order: -1 }, { field: \"num1\", order: 1 }] }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(10, dataSet.Count());
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(rows, dataSet.Count());
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(8, dataSet.FirstOrDefault()?.Num1);
-            Assert.Equal(9, dataSet.LastOrDefault()?.Num1);
+            Assert.Equal(90, dataSet.LastOrDefault()?.Num1);
             Assert.Equal("Test7", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal("Best3", dataSet.LastOrDefault()?.String1);
+            Assert.Equal("T7", dataSet.LastOrDefault()?.String1);
         }
 
 
         [Fact]
         public void List_Field_DateTime2_Where_2019_2_17_Test()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2019-02-17T00:00:00.000Z\", matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2019-02-17T00:00:00.000Z\", matchMode: \"dateIs\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            var dt = new DateTime(2019, 2, 17);
+            int counted = dataSet.Count(x => x.DateTime2.HasValue && x.DateTime2.Value == dt);
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal("Test7", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal(1, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact]
@@ -214,8 +243,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{}");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
             Assert.Equal(0, dataSet.Count());
         }
         
@@ -224,8 +254,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: null, matchMode: \"startsWith\" }, num1: { value: null, matchMode: \"startsWith\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
 
         [Fact] 
@@ -233,8 +264,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string2: { value: \"Test\", matchMode: \"equals\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(12, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact] 
@@ -242,8 +274,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test5\", matchMode: \"notContains\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => !x.String1.Contains("Test5"));
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(10, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact] 
@@ -251,8 +284,9 @@ namespace PrimeNG.TableFilter.Test
         {
             var filter = GenerateFilterTableFromJson("{ filters: { string1: { value: \"Test1\", matchMode: \"notEquals\" } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.String1 != "Test1");
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal(11, totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         
         [Fact]
@@ -272,15 +306,471 @@ namespace PrimeNG.TableFilter.Test
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal(1, totalRecord);
         }
-        
         [Fact]
-        public void Order_Table_Field_Num2_Where_5_Test()
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Bool")]
+        public void NullableBoolFilterShouldReturnSingleElement()
         {
-            var filter = GenerateFilterTableFromJson("{ filters: { num2: { value: 5, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10, sortField: \"Num1\",sortOrder: -1 }");
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: false, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
-            Assert.Equal("Best3", dataSet.FirstOrDefault()?.String1);
-            Assert.Equal(1, totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Bool")]
+        public void NullableBoolFilterShouldReturnTestDataWithoutNullableBoolFalse()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: false, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableBool.HasValue && x.NullableBool == false);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Bool")]
+        public void NullableBoolFilterShouldReturnTestDataWithoutNullableBoolTrue()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: true, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 50,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableBool.HasValue && x.NullableBool == true);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Bool")]
+        public void NullableBoolFilterShouldReturnInitialTestDataWhenNullableBoolNull()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: null, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 50,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Bool")]
+        public void NullableBoolFilterShouldReturnTwoElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableBool: { value: true, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(2, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnTestDataWithoutNullableShort5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableShort.HasValue && x.NullableShort.Value == 5);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnNullableShort5OrNullableShort6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort:  [ { matchMode: \"equals\", operator: \"or\", value: 5 }, { matchMode: \"equals\", operator: \"or\", value: 6 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableShort.HasValue && (x.NullableShort.Value == 5 || x.NullableShort.Value == 6));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturTestDataWithoutNullableShort5AndNullableShort6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort:  [ { matchMode: \"notEquals\", operator: \"and\", value: 5 }, { matchMode: \"notEquals\", operator: \"and\", value: 6 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => !(x.NullableShort.HasValue && (x.NullableShort.Value == 5 || x.NullableShort.Value == 6)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnNullableShort5OrNullableShort6In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort:   { matchMode: \"in\", operator: \"and\", value: [5,6] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => (x.NullableShort.HasValue && (x.NullableShort.Value == 5 || x.NullableShort.Value == 6)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 12, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnTestDataWithoutNullableInt12()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 12, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableInt.HasValue && x.NullableInt.Value == 12);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnNullableInt12OrNullableInt13()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt:  [ { matchMode: \"equals\", operator: \"or\", value: 12 }, { matchMode: \"equals\", operator: \"or\", value: 13 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableInt.HasValue && (x.NullableInt.Value == 12 || x.NullableInt.Value == 13));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturTestDataWithoutNullableInt12AndNullableInt13()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt:  [ { matchMode: \"notEquals\", operator: \"and\", value: 12 }, { matchMode: \"notEquals\", operator: \"and\", value: 13 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => !(x.NullableInt.HasValue && (x.NullableInt.Value == 12 || x.NullableInt.Value == 13)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnNullableInt12OrNullableInt13In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt:   { matchMode: \"in\", operator: \"and\", value: [12,13] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => (x.NullableInt.HasValue && (x.NullableInt.Value == 12 || x.NullableInt.Value == 13)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 55, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnTestDataWithoutNullableLong55()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 55, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableLong.HasValue && x.NullableLong.Value == 55);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnNullableLong55OrNullableLong56()
+                    
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong:  [ { matchMode: \"equals\", operator: \"or\", value: 55 }, { matchMode: \"equals\", operator: \"or\", value: 56 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableLong.HasValue && (x.NullableLong.Value == 55 || x.NullableLong.Value == 56));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturTestDataWithoutNullableLong55AndNullableLong56()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong:  [ { matchMode: \"notEquals\", operator: \"and\", value: 55 }, { matchMode: \"notEquals\", operator: \"and\", value: 56 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => !(x.NullableLong.HasValue && (x.NullableLong.Value == 55 || x.NullableLong.Value == 56)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnNullableLong55OrNullableLong56In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong:   { matchMode: \"in\", operator: \"and\", value: [55,56] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => (x.NullableLong.HasValue && (x.NullableLong.Value == 55 || x.NullableLong.Value == 56)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.1, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnTestDataWithoutNullableFloat5_1()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.1, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            float? value = (float?)5.1;
+            int counted = dataSet.Count(x => x.NullableFloat.HasValue && x.NullableFloat.Value == value);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnNullableFloat5_1OrNullableFloat5_2()
+
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat:  [ { matchMode: \"equals\", operator: \"or\", value: 5.1 }, { matchMode: \"equals\", operator: \"or\", value: 5.2 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            float? value1 = (float?)5.1;
+            float? value2 = (float?)5.2;
+            int counted = dataSet.Count(x => x.NullableFloat.HasValue && (x.NullableFloat.Value == value1 || x.NullableFloat.Value ==value2));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturTestDataWithoutNullableFloat5_1AndNullableFloat5_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat:  [ { matchMode: \"notEquals\", operator: \"and\", value: 5.1 }, { matchMode: \"notEquals\", operator: \"and\", value: 5.2 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            float? value1 = (float?)5.1;
+            float? value2 = (float?)5.2;
+            int counted = dataSet.Count(x => !(x.NullableFloat.HasValue && (x.NullableFloat.Value == value1 || x.NullableFloat.Value == value2)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnNullableFloat5_1OrNullableFloat5_2In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat:   { matchMode: \"in\", operator: \"and\", value: [5.1,5.2] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            float? value1 = (float?)5.1;
+            float? value2 = (float?)5.2;
+            int counted = dataSet.Count(x => (x.NullableFloat.HasValue && (x.NullableFloat.Value == value1 || x.NullableFloat.Value == value2)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.2, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnTestDataWithoutNullableFloat10_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.2, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableDouble.HasValue && x.NullableDouble.Value == 10.2);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnNullableDouble10_2OrNullableDouble10_3()
+
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble:  [ { matchMode: \"equals\", operator: \"or\", value: 10.2 }, { matchMode: \"equals\", operator: \"or\", value: 10.3 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableDouble.HasValue && (x.NullableDouble.Value == 10.2 || x.NullableDouble.Value == 10.3));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturTestDataWithoutNullableDouble10_2AndNullableDouble10_3()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble:  [ { matchMode: \"notEquals\", operator: \"and\", value: 10.2 }, { matchMode: \"notEquals\", operator: \"and\", value: 10.3 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => !(x.NullableDouble.HasValue && (x.NullableDouble.Value == 10.2 || x.NullableDouble.Value == 10.3)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnNullableDouble10_2OrNullableDouble10_3In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble:   { matchMode: \"in\", operator: \"and\", value: [10.2,10.3] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => (x.NullableDouble.HasValue && (x.NullableDouble.Value == 10.2 || x.NullableDouble.Value == 10.3)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")] 
+        public void NullableDecimalFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.5, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")] 
+        public void NullableDecimalFilterShouldReturnTestDataWithoutNullableDecimal22_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.5, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            decimal? value = (decimal?)22.5;
+            int counted = dataSet.Count(x => x.NullableDecimal.HasValue && x.NullableDecimal.Value == value);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")] 
+        public void NullableDecimalFilterShouldReturnNullableDecimal22_5OrNullableDecimal22_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal:  [ { matchMode: \"equals\", operator: \"or\", value: 22.5 }, { matchMode: \"equals\", operator: \"or\", value: 22.6 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            decimal? value1 = (decimal ?)22.5;
+            decimal? value2 = (decimal ?)22.6;
+            int counted = dataSet.Count(x => x.NullableDecimal.HasValue && (x.NullableDecimal.Value == value1 || x.NullableDecimal.Value == value2));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")] 
+        public void NullableDecimalFilterShouldReturTestDataWithoutNullableDecimal22_5AndNullableDecimal22_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal:  [ { matchMode: \"notEquals\", operator: \"and\", value: 22.5 }, { matchMode: \"notEquals\", operator: \"and\", value: 22.6 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            decimal? value1 = (decimal?)22.5;
+            decimal? value2 = (decimal?)22.6;
+            int counted = dataSet.Count(x => !(x.NullableDecimal.HasValue && (x.NullableDecimal.Value == value1 || x.NullableDecimal.Value == value2)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")] 
+        public void NullableDecimalFilterShouldReturnNullableDecimal22_5OrNullableDecimal22_6In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal:   { matchMode: \"in\", operator: \"and\", value: [22.5,22.6] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            decimal? value1 = (decimal?)22.5;
+            decimal? value2 = (decimal?)22.6;
+            int counted = dataSet.Count(x => (x.NullableDecimal.HasValue && (x.NullableDecimal.Value == value1 || x.NullableDecimal.Value == value2)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "DateTime")]
+        public void NullableDateTimeFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2021-11-05T00:00:00.000Z\", matchMode: \"dateIs\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Trait("Category", "Nullable")]
+        [Fact]
+        [Trait("Type", "DateTime")]
+        public void NullableDateTimeFilterShouldReturnTestDataWithoutDateTime2_2021_11_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2021-11-05T00:00:00.000Z\", matchMode: \"dateIsNot\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            DateTime dateTime = new DateTime(2021, 11, 5);
+            int counted = dataSet.Count(x => x.DateTime2.HasValue && x.DateTime2.Value == dateTime);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "DateTime")]
+        public void NullableDateTimeFilterShouldReturnTestDataBeforeDateTime2_2021_11_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2021-11-05T00:00:00.000Z\", matchMode: \"dateBefore\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            DateTime dateTime = new DateTime(2021, 11, 5);
+            int counted = dataSet.Count(x => x.DateTime2.HasValue && x.DateTime2.Value < dateTime);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal( counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "DateTime")]
+        public void NullableDateTimeFilterShouldReturnTestDataAfterDateTime2_2021_11_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { dateTime2: { value: \"2021-11-05T00:00:00.000Z\", matchMode: \"dateAfter\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            DateTime dateTime = new DateTime(2021, 11, 5);
+            int counted = dataSet.Count(x => x.DateTime2.HasValue && x.DateTime2.Value > dateTime);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal( counted, totalRecord);
         }
     }
 }

--- a/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
+++ b/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
@@ -374,6 +374,48 @@ namespace PrimeNG.TableFilter.Test
         [Fact]
         [Trait("Category", "Nullable")]
         [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnLessThan_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 6, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnLessOrEquals_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 6, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableShort <= 6);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted,totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnGreaterThan_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
+        public void NullablShortFilterShouldReturnGreaterOrEquals_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableShort >= 5);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Short")]
         public void NullablShortFilterShouldReturnTestDataWithoutNullableShort5()
         {
             var filter = GenerateFilterTableFromJson("{ filters: { nullableShort: { value: 5, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
@@ -427,6 +469,48 @@ namespace PrimeNG.TableFilter.Test
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnLessThan_13()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 13, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnLessOrEquals_13()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 13, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableInt <= 13);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnGreaterThan_12()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 12, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Int")]
+        public void NullableIntFilterShouldReturnGreaterOrEquals_12()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableInt: { value: 12, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableInt >= 12);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         [Fact]
         [Trait("Category", "Nullable")]
@@ -488,6 +572,48 @@ namespace PrimeNG.TableFilter.Test
         [Fact]
         [Trait("Category", "Nullable")]
         [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnLessThan_56()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 56, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnLessOrEquals_56()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 56, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableLong <= 56);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnGreaterThan_55()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 55, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
+        public void NullableLongFilterShouldReturnGreaterOrEquals_55()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 55, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableLong >= 55);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Long")]
         public void NullableLongFilterShouldReturnTestDataWithoutNullableLong55()
         {
             var filter = GenerateFilterTableFromJson("{ filters: { nullableLong: { value: 55, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
@@ -542,6 +668,48 @@ namespace PrimeNG.TableFilter.Test
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnLessThan_5_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.2, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnLessOrEquals_5_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.2, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableFloat <= (float?)5.2);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnGreaterThan_5_1()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.1, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Float")]
+        public void NullableFloatFilterShouldReturnGreaterOrEquals_5_1()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableFloat: { value: 5.1, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableFloat >= (float?)5.1);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         [Fact]
         [Trait("Category", "Nullable")]
@@ -609,7 +777,49 @@ namespace PrimeNG.TableFilter.Test
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Single(dataSet);
         }
-        
+        [Fact]
+        [Trait("Category", "Nullable")] 
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnLessThan_10_3()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.3, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnLessOrEquals_10_3()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.3, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableDouble <= (double?)10.3);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnGreaterThan_10_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.2, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Double")]
+        public void NullableDoubleFilterShouldReturnGreaterOrEquals_10_2()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDouble: { value: 10.2, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableDouble >= (double?)10.2);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+
         [Fact]
         [Trait("Category", "Nullable")]
         [Trait("Type", "Double")]
@@ -668,6 +878,48 @@ namespace PrimeNG.TableFilter.Test
             var dataSet = GenerateMockTestData();
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")]
+        public void NullableDecimalFilterShouldReturnLessThan_22_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.6, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")]
+        public void NullableDecimalFilterShouldReturnLessOrEquals_22_6()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.6, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableDecimal <= (decimal?)22.6);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")]
+        public void NullableDecimalFilterShouldReturnGreaterThan_22_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.5, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Decimal")]
+        public void NullableDecimalFilterShouldReturnGreaterOrEquals_22_5()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableDecimal: { value: 22.5, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableDecimal >= (decimal?)22.5);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
         [Fact]
         [Trait("Category", "Nullable")]

--- a/PrimeNG.TableFilter.Test/TestData.cs
+++ b/PrimeNG.TableFilter.Test/TestData.cs
@@ -8,6 +8,12 @@ namespace PrimeNG.TableFilter.Test
         public string String1 { get; set; }
         public DateTime DateTime1 { get; set; }
         public DateTime? DateTime2 { get; set; }
-        public int? Num2 { get; set; }
+        public bool? NullableBool { get; set; }
+        public short? NullableShort { get; set; }
+        public int? NullableInt { get; set; }
+        public long? NullableLong { get; set; }
+        public float? NullableFloat { get; set; }
+        public double? NullableDouble { get; set; }
+        public decimal? NullableDecimal { get; set; }
     }
 }

--- a/PrimeNG.TableFilter.sln
+++ b/PrimeNG.TableFilter.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31729.503
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimeNG.TableFilter", "PrimeNG.TableFilter\PrimeNG.TableFilter.csproj", "{24E4B117-295E-4C8D-B18C-4FD23F791B71}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrimeNG.TableFilter", "PrimeNG.TableFilter\PrimeNG.TableFilter.csproj", "{24E4B117-295E-4C8D-B18C-4FD23F791B71}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimeNG.TableFilter.Test", "PrimeNG.TableFilter.Test\PrimeNG.TableFilter.Test.csproj", "{0EE1CF24-9897-481C-B902-3DBDD98D0CBD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrimeNG.TableFilter.Test", "PrimeNG.TableFilter.Test\PrimeNG.TableFilter.Test.csproj", "{0EE1CF24-9897-481C-B902-3DBDD98D0CBD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,9 +15,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{24E4B117-295E-4C8D-B18C-4FD23F791B71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +41,11 @@ Global
 		{0EE1CF24-9897-481C-B902-3DBDD98D0CBD}.Release|x64.Build.0 = Release|Any CPU
 		{0EE1CF24-9897-481C-B902-3DBDD98D0CBD}.Release|x86.ActiveCfg = Release|Any CPU
 		{0EE1CF24-9897-481C-B902-3DBDD98D0CBD}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1D0017ED-B2A8-4CB1-A610-3095748C1A04}
 	EndGlobalSection
 EndGlobal

--- a/PrimeNG.TableFilter/Core/LinqOperator.cs
+++ b/PrimeNG.TableFilter/Core/LinqOperator.cs
@@ -1,9 +1,10 @@
-using System;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 using PrimeNG.TableFilter.Models;
 using PrimeNG.TableFilter.Utils;
+using System;
+using System.Linq;
+using System.Linq.Dynamic.Core;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace PrimeNG.TableFilter.Core
 {
@@ -31,7 +32,7 @@ namespace PrimeNG.TableFilter.Core
 
             var castValue = ObjectCasterUtil.CastPropertiesTypeList(property, propertyValue);
             var methodInfo = castValue.GetType()
-                .GetMethod(LinqOperatorConstants.ConstantContains, new[] {propertyType});
+                .GetMethod(LinqOperatorConstants.ConstantContains, new[] { propertyType });
 
             var list = Expression.Constant(castValue);
             var value = Expression.Property(_context.ParameterExpression, propertyName);
@@ -43,52 +44,92 @@ namespace PrimeNG.TableFilter.Core
         {
             var property = _context.DataSetType.GetProperty(propertyName);
             var propertyType = property?.PropertyType;
-            if (propertyType != typeof(string) && extensionMethod != LinqOperatorConstants.ConstantEquals)
-                throw new ArgumentException($"Property ${propertyName} not support method ${extensionMethod}");
-
             if (propertyType == null)
                 return;
+            if (!IsPropertyTypeAndFilterMatchModeValid(propertyType, extensionMethod))
+            {
+                throw new ArgumentException($"Property ${propertyName} not support method ${extensionMethod}");
+            }
 
-            var propertyAccess =
-                Expression.MakeMemberAccess(_context.ParameterExpression,
-                    property ?? throw new InvalidOperationException());
-            var methodInfo = propertyType.GetMethod(extensionMethod, new[] {propertyType});
+
             var castValue = ObjectCasterUtil.CastPropertiesType(property, propertyValue);
-            var propertyConstant = Expression.Convert(Expression.Constant(castValue), propertyType);
-            if (propertyType.IsGenericType
-                && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>)
-                && (propertyType == typeof(DateTime?) || propertyType == typeof(int?) || propertyType == typeof(double?)))
+            var propertyConstant = Expression.Constant(castValue, propertyType);
+
+            if (IsNullableType(propertyType))
             {
                 var converted = Expression.Convert(propertyConstant, typeof(object));
-                if (isNegation)
-                    AddNegationExpression(operatorAction, propertyAccess, methodInfo, converted);
+                if (castValue.GetType() == typeof(DateTime))
+                {
+                    ComposeLambdaForDateTimeProperty(propertyName, extensionMethod, operatorAction, isNegation, castValue);
+                }
+                else if (castValue.GetType() == typeof(bool))
+                {
+                    // boolean only have "equals" and "notEquals" match modes
+                    ComposeEqualsLinqExpression(propertyName, operatorAction, isNegation, castValue, _context.ParameterExpression);
+                }
+                // nullable numeric type
                 else
-                    AddNormalExpression(operatorAction, propertyAccess, methodInfo, converted);
+                {
+                    ComposeLambdaForNumericProperty(propertyName, extensionMethod, operatorAction, isNegation, castValue);
+                }
+
+
             }
             else
             {
-                if (isNegation)
-                    AddNegationExpression(operatorAction, propertyAccess, methodInfo, propertyConstant);
-                else
-                    AddNormalExpression(operatorAction, propertyAccess, methodInfo, propertyConstant);
-            }
-        }
+                if (castValue.GetType() == typeof(DateTime))
+                {
+                    ComposeLambdaForDateTimeProperty(propertyName, extensionMethod, operatorAction, isNegation, castValue);
+                }
+                else if (castValue.GetType() == typeof(bool))
+                {
+                    ComposeEqualsLinqExpression(propertyName, operatorAction, isNegation, castValue, _context.ParameterExpression);
+                    return;
+                }
+                else if (castValue.GetType() == typeof(string))
+                {
+                    var propertyAccess = Expression.MakeMemberAccess(_context.ParameterExpression,
+                                        property ?? throw new InvalidOperationException());
 
+                    var methodInfo = propertyType.GetMethod(extensionMethod, new[] { propertyType });
+                    if (isNegation)
+                        AddNegationExpression(operatorAction, propertyAccess, methodInfo, propertyConstant);
+                    else
+                        AddNormalExpression(operatorAction, propertyAccess, methodInfo, propertyConstant);
+
+                }
+                // nullable numeric type
+                else
+                {
+                    ComposeLambdaForNumericProperty(propertyName, extensionMethod, operatorAction, isNegation, castValue);
+
+                }
+            }
+
+        }
         private void AddNormalExpression(OperatorEnumeration operatorAction, Expression propertyAccess,
-            MethodInfo methodInfo, Expression converted)
+          MethodInfo methodInfo, Expression converted)
         {
             var callMethod = Expression.Call(propertyAccess,
                 methodInfo ?? throw new InvalidOperationException(), converted);
             AddLambdaExpression(operatorAction, callMethod);
         }
-
+        private void AddNormalExpression(OperatorEnumeration operatorAction, Expression propertyAccess)
+        {
+            AddLambdaExpression(operatorAction, propertyAccess);
+        }
         private void AddNegationExpression(OperatorEnumeration operatorAction, MemberExpression propertyAccess,
-            MethodInfo methodInfo, Expression converted)
+    MethodInfo methodInfo, Expression converted)
         {
             if (propertyAccess == null) throw new ArgumentNullException(nameof(propertyAccess));
             var callMethod = Expression.Not(Expression.Call(propertyAccess,
                 methodInfo ?? throw new InvalidOperationException(), converted));
             AddLambdaExpression(operatorAction, callMethod);
+        }
+        private void AddNegationExpression(OperatorEnumeration operatorAction, Expression propertyAccess)
+        {
+            AddLambdaExpression(operatorAction, Expression.Not(propertyAccess));
+
         }
 
         private void AddLambdaExpression(OperatorEnumeration operatorAction, Expression callMethod)
@@ -101,6 +142,7 @@ namespace PrimeNG.TableFilter.Core
                 switch (operatorAction)
                 {
                     case OperatorEnumeration.And:
+
                         _context.Expressions =
                             Expression.Lambda<Func<TEntity, bool>>(
                                 Expression.AndAlso(_context.Expressions.Body, lambda.Body),
@@ -147,9 +189,189 @@ namespace PrimeNG.TableFilter.Core
                     property ?? throw new InvalidOperationException());
             var orderByExpression = Expression.Lambda(propertyAccess, _context.ParameterExpression);
             var resultExpression = Expression.Call(typeof(Queryable), command,
-                new[] {_context.DataSetType, property.PropertyType},
+                new[] { _context.DataSetType, property.PropertyType },
                 _context.DataSet.Expression, Expression.Quote(orderByExpression));
             _context.DataSet = _context.DataSet.Provider.CreateQuery<TEntity>(resultExpression);
+        }
+        /// <summary>
+        /// Checks if provided type is nullable
+        /// </summary>
+        /// <param name="propertyType">Type to check</param>
+        /// <returns><code>True</code> if nullable, otherwise <code>False</code></returns>
+        private static bool IsNullableType(Type propertyType)
+        {
+            return propertyType.IsGenericType
+                       && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
+        /// <summary>
+        /// Checks if provided type is numeric type
+        /// </summary>
+        /// <param name="propertyType">Type to check</param>
+        /// <returns><code>True</code> if nullable, otherwise <code>False</code></returns>
+        private bool IsNumericType(Type propertyType)
+        {
+            return (propertyType == typeof(short) || propertyType == typeof(short?) || propertyType == typeof(int) || propertyType == typeof(int?) || propertyType == typeof(long) || propertyType == typeof(long?)
+                  || propertyType == typeof(float) || propertyType == typeof(float?) || propertyType == typeof(double) || propertyType == typeof(double?) || propertyType == typeof(decimal) || propertyType == typeof(decimal?));
+        }
+        /// <summary>
+        /// Checks if for provided <paramref name="propertyType"/>, <paramref name="extensionMethod"/> is valid
+        /// </summary>
+        /// <param name="propertyType">Type of filter value instance</param>
+        /// <param name="extensionMethod">Method to check for provided <paramref name="propertyType"/> </param>
+        /// <returns></returns>
+        private bool IsPropertyTypeAndFilterMatchModeValid(Type propertyType, string extensionMethod)
+        {
+            if (propertyType == typeof(DateTime) || propertyType == typeof(DateTime?))
+            {
+                var validDateTimeLinqMethods = new string[] { LinqOperatorConstants.ConstantDateIs, LinqOperatorConstants.ConstantBefore, LinqOperatorConstants.ConstantAfter };
+                return validDateTimeLinqMethods.Contains(extensionMethod);
+            }
+            else if (propertyType == typeof(string))
+            {
+                var validStringLinqMethods = new string[] { LinqOperatorConstants.ConstantEquals, LinqOperatorConstants.ConstantEndsWith, LinqOperatorConstants.ConstantContains, LinqOperatorConstants.ConstantStartsWith };
+                return validStringLinqMethods.Contains(extensionMethod);
+            }
+            else if (propertyType == typeof(bool) || propertyType == typeof(bool?))
+            {
+                return LinqOperatorConstants.ConstantEquals == extensionMethod;
+            }
+            else if (IsNumericType(propertyType))
+            {
+                var validNumericMethods = new string[] { LinqOperatorConstants.ConstantEquals, LinqOperatorConstants.ConstantLessThan, LinqOperatorConstants.ConstantLessThanOrEqual, LinqOperatorConstants.ConstantGreaterThan, LinqOperatorConstants.ConstantGreaterThanOrEqual };
+                return validNumericMethods.Contains(extensionMethod);
+            }
+            else
+                return false;
+
+        }
+
+
+
+        /// <summary>
+        /// Composes LINQ expression for numeric type of based on <paramref name="extensionMethod"/>
+        /// </summary>
+        /// <param name="propertyName">Name of property to compose expression</param>
+        /// <param name="extensionMethod">Extension method for which expression is composed</param>
+        /// <param name="operatorAction">Operator action for expression</param>
+        /// <param name="isNegation">Flag that indicates if expression should be negation</param>
+        /// <param name="castValue">Casted value of <paramref name="propertyName"/></param>
+        private void ComposeLambdaForNumericProperty(string propertyName, string extensionMethod, OperatorEnumeration operatorAction, bool isNegation, object castValue)
+        {
+            LambdaExpression dynamicExpression;
+            ParameterExpression x = _context.ParameterExpression;
+            switch (extensionMethod)
+            {
+                case LinqOperatorConstants.ConstantEquals:
+                    {
+                        dynamicExpression = ComposeEqualsLinqExpression(propertyName, operatorAction, isNegation, castValue, x);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantLessThan:
+                    {
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}<@0", castValue);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantLessThanOrEqual:
+                    {
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}<=@0", castValue);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantGreaterThan:
+                    {
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}>@0", castValue);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantGreaterThanOrEqual:
+                    {
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}>=@0", castValue);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+
+                default:
+                    break;
+            }
+        }
+
+        private LambdaExpression ComposeEqualsLinqExpression(string propertyName, OperatorEnumeration operatorAction, bool isNegation, object castValue, ParameterExpression x)
+        {
+            LambdaExpression dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}==@0", castValue);
+            if (isNegation)
+                AddNegationExpression(operatorAction, dynamicExpression.Body);
+            else
+                AddNormalExpression(operatorAction, dynamicExpression.Body);
+            return dynamicExpression;
+        }
+
+        /// <summary>
+        /// Composes LINQ expression for date time based on <paramref name="extensionMethod"/>
+        /// </summary>
+        /// <param name="propertyName">Name of property to compose expression</param>
+        /// <param name="extensionMethod">Extension method for which expression is composed</param>
+        /// <param name="operatorAction">Operator action for expression</param>
+        /// <param name="isNegation">Flag that indicates if expression should be negation</param>
+        /// <param name="castValue">Casted value of <paramref name="propertyName"/></param>
+        private void ComposeLambdaForDateTimeProperty(string propertyName, string extensionMethod, OperatorEnumeration operatorAction, bool isNegation, object castValue)
+        {
+            var dateTime = (DateTime)castValue;
+            LambdaExpression dynamicExpression;
+            bool hoursDefined = dateTime.TimeOfDay.Hours > 0;
+            bool minutesDefined = dateTime.TimeOfDay.Minutes > 0;
+            bool secondsDefined = dateTime.TimeOfDay.Seconds > 0;
+            bool isTimeDefined = hoursDefined || minutesDefined || secondsDefined;
+            switch (extensionMethod)
+            {
+                case LinqOperatorConstants.ConstantDateIs:
+                    {
+                        ParameterExpression x = _context.ParameterExpression;
+
+                        dynamicExpression = isTimeDefined ?
+                             DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}==@0", dateTime)
+                            : DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}>=@0 && {propertyName}<= @1", dateTime.Date, dateTime.Date.AddDays(1).AddTicks(-1));
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantBefore:
+                    {
+                        ParameterExpression x = _context.ParameterExpression;
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}<@0", dateTime);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                case LinqOperatorConstants.ConstantAfter:
+                    {
+                        ParameterExpression x = _context.ParameterExpression;
+                        dynamicExpression = DynamicExpressionParser.ParseLambda(new ParameterExpression[] { x }, null, $"{propertyName}>@0", dateTime);
+                        if (isNegation)
+                            AddNegationExpression(operatorAction, dynamicExpression.Body);
+                        else
+                            AddNormalExpression(operatorAction, dynamicExpression.Body);
+                        break;
+                    }
+                default:
+                    break;
+            }
         }
 
         public IQueryable<TEntity> GetResult() => _context.DataSet;

--- a/PrimeNG.TableFilter/Core/LinqOperatorConstants.cs
+++ b/PrimeNG.TableFilter/Core/LinqOperatorConstants.cs
@@ -11,5 +11,14 @@ namespace PrimeNG.TableFilter.Core
         public const string ConstantContains = "Contains";
         public const string ConstantEndsWith = "EndsWith";
         public const string ConstantEquals = "Equals";
+
+        public const string ConstantLessThan = "lt";
+        public const string ConstantLessThanOrEqual = "lte";
+        public const string ConstantGreaterThan = "gt";
+        public const string ConstantGreaterThanOrEqual = "gte";
+
+        public const string ConstantDateIs = "DateIs";
+        public const string ConstantBefore = "DateBefore";
+        public const string ConstantAfter = "DateAfter";
     }
 }

--- a/PrimeNG.TableFilter/Core/TableFilterManager.cs
+++ b/PrimeNG.TableFilter/Core/TableFilterManager.cs
@@ -151,6 +151,27 @@ namespace PrimeNG.TableFilter.Core
                         LinqOperatorConstants.ConstantAfter
                         , operatorAction);
                     break;
+                case FilterTypeMatchModeLessThan:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantLessThan
+                        , operatorAction);
+                    break;
+                case FilterTypeMatchModeLessOrEqualsThan:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantLessThanOrEqual
+                        , operatorAction);
+                    break;
+                case FilterTypeMatchModeGreaterThan:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantGreaterThan
+                        , operatorAction);
+                    break;
+                case FilterTypeMatchModeGreaterOrEqualsThan:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantGreaterThanOrEqual
+                        , operatorAction);
+                    break;
+
 
                 default:
                     throw new System.ArgumentException("Invalid Match mode!");

--- a/PrimeNG.TableFilter/Core/TableFilterManager.cs
+++ b/PrimeNG.TableFilter/Core/TableFilterManager.cs
@@ -9,11 +9,25 @@ namespace PrimeNG.TableFilter.Core
     {
         private const string FilterTypeMatchModeStartsWith = "startsWith";
         private const string FilterTypeMatchModeContains = "contains";
-        private const string FilterTypeMatchModeIn = "in";
+        private const string FilterTypeMatchModeNotContains = "notContains";
         private const string FilterTypeMatchModeEndsWith = "endsWith";
         private const string FilterTypeMatchModeEquals = "equals";
-        private const string FilterTypeMatchModeNotContains = "notContains";
         private const string FilterTypeMatchModeNotEquals = "notEquals";
+        private const string FilterTypeMatchModeIn = "in";
+        private const string FilterTypeMatchModeLessThan = "lt";
+        private const string FilterTypeMatchModeLessOrEqualsThan = "lte";
+        private const string FilterTypeMatchModeGreaterThan = "gt";
+        private const string FilterTypeMatchModeGreaterOrEqualsThan = "gte";
+        private const string FilterTypeMatchModeBetween = "between";
+        private const string FilterTypeMatchModeIs = "is";
+        private const string FilterTypeMatchModeIsNot = "isNot";
+        private const string FilterTypeMatchModeBefore = "before";
+        private const string FilterTypeMatchModeAfter = "after";
+        private const string FilterTypeMatchModeDateIs = "dateIs";
+        private const string FilterTypeMatchModeDateIsNot = "dateIsNot";
+        private const string FilterTypeMatchModeDateBefore = "dateBefore";
+        private const string FilterTypeMatchModeDateAfter = "dateAfter";
+
 
         private readonly ILinqOperator<TEntity> _linqOperator;
 
@@ -116,6 +130,26 @@ namespace PrimeNG.TableFilter.Core
                     _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
                         LinqOperatorConstants.ConstantEquals
                         , operatorAction, true);
+                    break;
+                case FilterTypeMatchModeDateIs:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantDateIs
+                        , operatorAction);
+                    break;
+                case FilterTypeMatchModeDateIsNot:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantDateIs
+                        , operatorAction,true);
+                    break;
+                case FilterTypeMatchModeDateBefore:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantBefore
+                        , operatorAction);
+                    break;
+                case FilterTypeMatchModeDateAfter:
+                    _linqOperator.AddFilterProperty(key.FirstCharToUpper(), value.Value,
+                        LinqOperatorConstants.ConstantAfter
+                        , operatorAction);
                     break;
 
                 default:

--- a/PrimeNG.TableFilter/PrimeNG.TableFilter.csproj
+++ b/PrimeNG.TableFilter/PrimeNG.TableFilter.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.13" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.md">

--- a/PrimeNG.TableFilter/PrimeNGTableFilterExtension.cs
+++ b/PrimeNG.TableFilter/PrimeNGTableFilterExtension.cs
@@ -39,8 +39,9 @@ namespace PrimeNG.TableFilter
                         }
                         case JObject _:
                         {
-                            var filter = filterToken.ToObject<TableFilterContext>();
-                            tableFilterManager.FilterDataSet(filterContext.Key, filter);
+                                //var filter = filterToken.ToObject<TableFilterContext>(JsonSerializer.Create( new JsonSerializerSettings() { DateParseHandling= DateParseHandling.DateTime })) ;
+                                var filter = filterToken.ToObject<TableFilterContext>();
+                                tableFilterManager.FilterDataSet(filterContext.Key, filter);
                             break;
                         }
                     }

--- a/PrimeNG.TableFilter/Utils/ObjectCasterUtil.cs
+++ b/PrimeNG.TableFilter/Utils/ObjectCasterUtil.cs
@@ -15,31 +15,55 @@ namespace PrimeNG.TableFilter.Utils
                 return arrayCast.ToObject<List<int>>();
             if (property?.PropertyType == typeof(double))
                 return arrayCast.ToObject<List<double>>();
-            if (property?.PropertyType == typeof(int?))
-                return arrayCast.ToObject<List<int?>>();
-            if (property?.PropertyType == typeof(double?))
-                return arrayCast.ToObject<List<double?>>();
             if (property?.PropertyType == typeof(DateTime))
                 return arrayCast.ToObject<List<DateTime>>();
             if (property?.PropertyType == typeof(DateTime?))
                 return arrayCast.ToObject<List<DateTime?>>();
+            if (property?.PropertyType == typeof(bool?))
+                return arrayCast.ToObject<List<bool?>>();
+            if (property?.PropertyType == typeof(short?))
+                return arrayCast.ToObject<List<short?>>();
+            if (property?.PropertyType == typeof(int?))
+                return arrayCast.ToObject<List<int?>>();
+            if (property?.PropertyType == typeof(long?))
+                return arrayCast.ToObject<List<long?>>();
+            if (property?.PropertyType == typeof(float?))
+                return arrayCast.ToObject<List<float?>>();
+            if (property?.PropertyType == typeof(double?))
+                return arrayCast.ToObject<List<double?>>();
+            if (property?.PropertyType == typeof(decimal?))
+                return arrayCast.ToObject<List<decimal?>>();
+
             return arrayCast.ToObject<List<string>>();
         }
 
         public static object CastPropertiesType(PropertyInfo property, object value)
         {
+                
             if (property?.PropertyType == typeof(int))
                 return Convert.ToInt32(value);
             if (property?.PropertyType == typeof(double))
-                return Convert.ToDouble(value);
-            if (property?.PropertyType == typeof(int?))
-                return Convert.ToInt32(value);
-            if (property?.PropertyType == typeof(double?))
                 return Convert.ToDouble(value);
             if (property?.PropertyType == typeof(DateTime))
                 return Convert.ToDateTime(value);
             if (property?.PropertyType == typeof(DateTime?))
                 return Convert.ToDateTime(value);
+            if (property?.PropertyType == typeof(bool?))
+                return Convert.ToBoolean(value);
+            if (property?.PropertyType == typeof(short?))
+                return Convert.ToInt16(value);
+            if (property?.PropertyType == typeof(int?))
+                return Convert.ToInt32(value);
+            if (property?.PropertyType == typeof(long?))
+                return Convert.ToInt64(value);
+            if (property?.PropertyType == typeof(float?))
+                return Convert.ToSingle(value);
+            if (property?.PropertyType == typeof(double?))
+                return Convert.ToDouble(value);
+            if (property?.PropertyType == typeof(decimal?))
+                return Convert.ToDecimal(value);
+            
+
             return value.ToString();
         }
 


### PR DESCRIPTION
* Added support for non string values for filtering
Supported filter match modes per data type are listed [here](https://primefaces.org/primeng/showcase/#/table
) **Search "Match modes" section**



* Added support for non string nullable values for filtering (bool? short? int? long? float? double? decimal?,DateTime?)

* Support for non string  data types is provided with System.Linq.Dynamic.Core Nuget package.
Documentation on [link](https://dynamic-linq.net/overview) 
* Added tests for nullable types as well as making existing tests less fragile (swapping hard coded count values with linq expressions that return count with or without predicate expression, depending on test itself