### PR TITLE
Add support for Byte property type

### DIFF
--- a/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
+++ b/PrimeNG.TableFilter.Test/PrimeNGTableFilterIQueryableTest.cs
@@ -43,6 +43,8 @@ namespace PrimeNG.TableFilter.Test
                 new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B1", NullableDecimal = (decimal?)22.6 },
                 new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", DateTime2 = new DateTime(2021,11,5) },
                 new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", DateTime2 = new DateTime(2021,11,8) },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", NullableByte = (byte?)27 },
+                new TestData { DateTime1 = new DateTime(2021, 11, 1), Num1 = 90, String1 = "B2", NullableByte = (byte?)28 },
             }.AsQueryable();
         }
 
@@ -1023,6 +1025,105 @@ namespace PrimeNG.TableFilter.Test
             int counted = dataSet.Count(x => x.DateTime2.HasValue && x.DateTime2.Value > dateTime);
             dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
             Assert.Equal( counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnSingleElement()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 27, matchMode: \"equals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnLessThan_28()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 28, matchMode: \"lt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnLessOrEquals_28()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 28, matchMode: \"lte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableByte <= 28);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnGreaterThan_27()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 27, matchMode: \"gt\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Single(dataSet);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnGreaterOrEquals_27()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 27, matchMode: \"gte\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableByte >= 27);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnTestDataWithoutNullableByte27()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte: { value: 27, matchMode: \"notEquals\" }  } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => x.NullableByte.HasValue && x.NullableByte.Value == 27);
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(initialCount - counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturnNullableByte27OrNullableByte28()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte:  [ { matchMode: \"equals\", operator: \"or\", value: 27 }, { matchMode: \"equals\", operator: \"or\", value: 28 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int counted = dataSet.Count(x => x.NullableByte.HasValue && (x.NullableByte.Value == 27 || x.NullableByte.Value == 28));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullableByteFilterShouldReturTestDataWithoutNullableByte27AndNullableByte28()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte:  [ { matchMode: \"notEquals\", operator: \"and\", value: 27 }, { matchMode: \"notEquals\", operator: \"and\", value: 28 } ] } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => !(x.NullableByte.HasValue && (x.NullableByte.Value == 27 || x.NullableByte.Value == 28)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
+        }
+        [Fact]
+        [Trait("Category", "Nullable")]
+        [Trait("Type", "Byte")]
+        public void NullablByteFilterShouldReturnNullableByte27OrNullableByte28In()
+        {
+            var filter = GenerateFilterTableFromJson("{ filters: { nullableByte:   { matchMode: \"in\", operator: \"and\", value: [27,28] } } , first: 0, globalFilter: null, multiSortMeta: undefined, rows: 10,sortOrder: -1 }");
+            var dataSet = GenerateMockTestData();
+            int initialCount = dataSet.Count();
+            int counted = dataSet.Count(x => (x.NullableByte.HasValue && (x.NullableByte.Value == 27 || x.NullableByte.Value == 28)));
+            dataSet = dataSet.PrimengTableFilter(filter, out var totalRecord);
+            Assert.Equal(counted, totalRecord);
         }
     }
 }

--- a/PrimeNG.TableFilter.Test/TestData.cs
+++ b/PrimeNG.TableFilter.Test/TestData.cs
@@ -15,5 +15,6 @@ namespace PrimeNG.TableFilter.Test
         public float? NullableFloat { get; set; }
         public double? NullableDouble { get; set; }
         public decimal? NullableDecimal { get; set; }
+        public byte? NullableByte { get; set; }
     }
 }

--- a/PrimeNG.TableFilter/Core/LinqOperator.cs
+++ b/PrimeNG.TableFilter/Core/LinqOperator.cs
@@ -221,7 +221,8 @@ namespace PrimeNG.TableFilter.Core
         private static bool IsNumericType(Type propertyType)
         {
             return (propertyType == typeof(short) || propertyType == typeof(short?) || propertyType == typeof(int) || propertyType == typeof(int?) || propertyType == typeof(long) || propertyType == typeof(long?)
-                  || propertyType == typeof(float) || propertyType == typeof(float?) || propertyType == typeof(double) || propertyType == typeof(double?) || propertyType == typeof(decimal) || propertyType == typeof(decimal?));
+                  || propertyType == typeof(float) || propertyType == typeof(float?) || propertyType == typeof(double) || propertyType == typeof(double?) || propertyType == typeof(decimal) || propertyType == typeof(decimal?))
+                  || propertyType == typeof(byte) || propertyType == typeof(byte?);
         }
         /// <summary>
         /// Checks if for provided <paramref name="propertyType"/>, <paramref name="extensionMethod"/> is valid

--- a/PrimeNG.TableFilter/Utils/ObjectCasterUtil.cs
+++ b/PrimeNG.TableFilter/Utils/ObjectCasterUtil.cs
@@ -43,6 +43,10 @@ namespace PrimeNG.TableFilter.Utils
                 return arrayCast.ToObject<List<decimal>>();
             if (property?.PropertyType == typeof(decimal?))
                 return arrayCast.ToObject<List<decimal?>>();
+            if (property?.PropertyType == typeof(byte))
+                return arrayCast.ToObject<List<byte>>();
+            if (property?.PropertyType == typeof(byte?))
+                return arrayCast.ToObject<List<byte?>>();
 
             return arrayCast.ToObject<List<string>>();
         }
@@ -82,7 +86,10 @@ namespace PrimeNG.TableFilter.Utils
                 return Convert.ToDecimal(value);
             if (property?.PropertyType == typeof(decimal?))
                 return Convert.ToDecimal(value);
-            
+            if (property?.PropertyType == typeof(byte))
+                return Convert.ToByte(value);
+            if (property?.PropertyType == typeof(byte?))
+                return Convert.ToByte(value);
 
             return value.ToString();
         }


### PR DESCRIPTION
We have some table fields which are defined as Byte, as we only expect a very small number, but we'd like to do filtering on these fields.

Here is a change which includes Byte, including a set of Unit tests.

Thanks for your work on this library, it's allowed us to use the Prime grids in our UI application with very little work!